### PR TITLE
Fix broken stylesheet and favicon links

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
   <meta property="og:image" content="/assets/logo-full.png" />
   <meta property="og:url" content="https://your-domain.com" />
 
-  <link rel="icon" href="/assets/favicon.png" />
+  <link rel="icon" href="/assets/favicon-32.png" type="image/png" />
   <link rel="preload" href="/assets/logo-full.png" as="image" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/styles.css" />
 </head>
 <body class="dark">
   <!-- Header -->


### PR DESCRIPTION
## Summary
- Reference existing favicon file instead of missing `favicon.png`
- Correct HTML to load `styles.css` so the landing page renders with intended styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689826cf8c7883259d083f33c1d0efa3